### PR TITLE
Potential fix for code scanning alert no. 4: Incomplete string escaping or encoding

### DIFF
--- a/js/tablesorte.js
+++ b/js/tablesorte.js
@@ -30,7 +30,7 @@ $(document).ready(function(){
 // Get query string
 function query_string( key ) {
 	default_="";
-	key = key.replace(/\[/g, "\\[").replace(/\]/g, "\\]");
+	key = key.replace(/\\/g, "\\\\").replace(/\[/g, "\\[").replace(/\]/g, "\\]");
 	var regex = new RegExp("[\\?&]"+key+"=([^&#]*)");
 	var qs = regex.exec(window.location.href);
 	if(qs == null)


### PR DESCRIPTION
Potential fix for [https://github.com/roipmars/sl.roipmars.org.my/security/code-scanning/4](https://github.com/roipmars/sl.roipmars.org.my/security/code-scanning/4)

To fix the problem, we need to ensure that backslashes in the input are properly escaped. This can be done by adding an additional `replace` call to handle backslashes. The best way to fix this without changing existing functionality is to modify the `query_string` function to include escaping for backslashes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
